### PR TITLE
Add model doc strings to the api view so they're available through the web interface

### DIFF
--- a/data_management/api_views.py
+++ b/data_management/api_views.py
@@ -107,6 +107,7 @@ for name, cls in models.all_models.items():
         'model': cls,
         'serializer_class': getattr(serializers, name + 'Serializer'),
         'filterset_fields': cls.FILTERSET_FIELDS,
+        '__doc__': cls.__doc__
     }
     globals()[name + "ViewSet"] = type(name + "ViewSet", (BaseViewSet,), data)
 

--- a/data_management/models.py
+++ b/data_management/models.py
@@ -88,7 +88,30 @@ class URIField(models.URLField):
 
 class StorageRoot(BaseModel):
     """
-    The root location of a storage cache where model files are stored.
+***The root location of a storage cache where model files are stored.***
+
+### Writeable Fields:
+`name`: Name of the StorageRoot, unique in the context of `StorageRoot`s
+
+`description`: Description of the StorageRoot
+
+`uri`: URI (including protocol) to the root of a `StorageLocation`, when prepended to a `StorageLocation` `path`
+produces a complete URI to a file. Examples:
+
+    - https://somewebsite.com/
+    - ftp://host/ (ftp://username:password@host:port/)
+    - ssh://host/
+    - file:///someroot/ (file://C:\)
+    - github://org:repo@sha/ (github://org:repo/ (master))
+
+`type`: Reference to the `StorageType` of this `StorageRoot`
+
+### Read-only Fields:
+`url`: url link to the instance of the `StorageRoot`, final integer is the `StorageRoot`'s id
+
+`last_updated`: datetime that this record was last updated
+
+`updated_by`: id of the user that updated this record
     """
     type = models.ForeignKey(StorageType, on_delete=models.CASCADE, null=False)
     description = models.TextField(max_length=1024, null=True, blank=True)

--- a/data_management/models.py
+++ b/data_management/models.py
@@ -90,28 +90,28 @@ class StorageRoot(BaseModel):
     """
 ***The root location of a storage cache where model files are stored.***
 
-### Writeable Fields:
-`name`: Name of the StorageRoot, unique in the context of `StorageRoot`s
+### Writable Fields:
+`name`: Name of the `StorageRoot`, unique in the context of `StorageRoot`
 
-`description`: Description of the StorageRoot
+`description`: Free text description of the `StorageRoot`
 
 `uri`: URI (including protocol) to the root of a `StorageLocation`, when prepended to a `StorageLocation` `path`
 produces a complete URI to a file. Examples:
 
-    - https://somewebsite.com/
-    - ftp://host/ (ftp://username:password@host:port/)
-    - ssh://host/
-    - file:///someroot/ (file://C:\)
-    - github://org:repo@sha/ (github://org:repo/ (master))
+* https://somewebsite.com/
+* ftp://host/ (ftp://username:password@host:port/)
+* ssh://host/
+* file:///someroot/ (file://C:\)
+* github://org:repo@sha/ (github://org:repo/ (master))
 
-`type`: Reference to the `StorageType` of this `StorageRoot`
+`type`: Reference to the `StorageType` of the `StorageRoot`
 
 ### Read-only Fields:
-`url`: url link to the instance of the `StorageRoot`, final integer is the `StorageRoot`'s id
+`url`: Reference to the instance of the `StorageRoot`, final integer is the `StorageRoot` id
 
 `last_updated`: datetime that this record was last updated
 
-`updated_by`: id of the user that updated this record
+`updated_by`: Reference to the user that updated this record
     """
     type = models.ForeignKey(StorageType, on_delete=models.CASCADE, null=False)
     description = models.TextField(max_length=1024, null=True, blank=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ requests-oauthlib==1.3.0
 six==1.14.0
 sqlparse==0.3.1
 urllib3==1.25.9
+Markdown==3.2.2


### PR DESCRIPTION
I was wanting to document the meaning of the fields somewhere, I thought having it within the data registry might mean it would be kept up-to-date and easily findable. Not sure if there's a nicer way to do this, so consider this a POC that is potentially mergable.

![image](https://user-images.githubusercontent.com/45965483/86775903-ad42b180-c04f-11ea-9337-c6b6f7a2f7a8.png)
