### PR TITLE
Add whitenoise to serve static files for local reg

### DIFF
--- a/drams/local-settings.py
+++ b/drams/local-settings.py
@@ -24,7 +24,7 @@ SECRET_KEY = '91qh0bw%vj8jd(+s1dos++=thx3v165*jlejlt9l-e&2b1*@ak'
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 # DEBUG_PROPAGATE_EXCEPTIONS = True
 
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -151,6 +152,7 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 STATICFILES_DIRS = [
 ]
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -37,3 +37,4 @@ django-crispy-forms==1.9.2
 Markdown==3.2.2
 django-nose==1.4.6
 setuptools~=54.2.0
+whitenoise==5.2.0

--- a/scripts/rebuild-local.sh
+++ b/scripts/rebuild-local.sh
@@ -5,4 +5,5 @@ rm db.sqlite3
 python3 manage.py makemigrations custom_user
 python3 manage.py makemigrations data_management
 python3 manage.py migrate
+python3 manage.py collectstatic --noinput
 python3 manage.py createsuperuser --noinput


### PR DESCRIPTION
By using whitenoise in the local version of the registry, we can turn dajngo's DEBUG flag off and make it less chatty.